### PR TITLE
しゃがみ判定と前傾、後傾のロジックを調整

### DIFF
--- a/backend/pose_test.py
+++ b/backend/pose_test.py
@@ -17,7 +17,7 @@ SMOOTHING_STREAK = 3
 
 
 def main():
-    cap = cv2.VideoCapture(1)
+    cap = cv2.VideoCapture(0, cv2.CAP_DSHOW)  # CAP_DSHOWはWindowsでのカメラ遅延回避用
     if not cap.isOpened():
         print("Error: Camera not found.")
         return


### PR DESCRIPTION
基本的には斜め前を向いた状態での判定。
なんかパンチは肩と同じ高さですると判定されやすいです。
右向きでも左向きでもプレイできるようにしたかったため、前傾後傾の判定をx,yの判定からカメラからの距離による判定に変更。
しゃがみ判定を90度での判定から数値での判定に変更。
他、様々な判定の調整。